### PR TITLE
two minor bugfixes

### DIFF
--- a/utilities/ConvertTo-PoshTools.ps1
+++ b/utilities/ConvertTo-PoshTools.ps1
@@ -97,8 +97,13 @@ function Out-ObjectProperty {
             $value =  "New-Object -TypeName '$($PropertyType.FullName)' -ArgumentList @('$($parts[0])', $($parts[1].Trim('pt')))"
         }
         elseif ($propertyType.FullName -eq "System.Drawing.Color") {
-            $color =  "[System.Drawing.Color]::$($property.InnerText)"
-            $value =  "[System.Drawing.Color]::FromArgb($color.ToArgb())"
+            If ([System.Drawing.SystemColors]::$($Property.InnerText)){
+                $value =  "[System.Drawing.SystemColors]::$($property.InnerText)"
+            } elseif ([System.Drawing.Color]::$($Property.InnerText)){
+                $value =  "[System.Drawing.Color]::$($property.InnerText)"
+            } else {
+                $value =  "[System.Drawing.Color]::FromArgb($($Property.InnerText))"
+            }
         }
         elseif ($propertyType.IsEnum) {
             $value = ($property.innerText -split ',' | ForEach-Object { "[$($propertyType.FullName)]::$($_.Trim())" }) -join ' -bor '

--- a/utilities/ConvertTo-PoshTools.ps1
+++ b/utilities/ConvertTo-PoshTools.ps1
@@ -97,7 +97,8 @@ function Out-ObjectProperty {
             $value =  "New-Object -TypeName '$($PropertyType.FullName)' -ArgumentList @('$($parts[0])', $($parts[1].Trim('pt')))"
         }
         elseif ($propertyType.FullName -eq "System.Drawing.Color") {
-            $value =  "[System.Drawing.Color]::FromArgb($($property.InnerText))"
+            $color =  "[System.Drawing.Color]::$($property.InnerText)"
+            $value =  "[System.Drawing.Color]::FromArgb($color.ToArgb())"
         }
         elseif ($propertyType.IsEnum) {
             $value = ($property.innerText -split ',' | ForEach-Object { "[$($propertyType.FullName)]::$($_.Trim())" }) -join ' -bor '
@@ -207,7 +208,7 @@ $Script | Out-File -FilePath (Join-Path $OutputPath ($fi.Name + ".ps1" ))
 
 Write-Host "Conversion complete: `r`n You need to update your PSSProj by adding the following to the contents via a text editor:"
 Write-Host "<ItemGroup>
-<Compile Include=`"$($fi.Name).designer.ps1')`">
+<Compile Include=`"$($fi.Name).designer.ps1`">
     <SubType>Code</SubType>
     <DependentUpon>$($fi.Name + ".ps1")</DependentUpon>
 </Compile>


### PR DESCRIPTION
Line 210 looks like a typo, was appending ') to the end of the designer filename.

Line 100 was passing the color as unquoted text to from argb.  So:
  [system.drawing.color]::FromArgb(red) in my case.  I guess powershell studio isn't returning the actual rgb code.  Added code to compute that from the color text and insert that instead.